### PR TITLE
Bump IPAddressRange to 3.2.0.0

### DIFF
--- a/BuildNuGetPackage/WhoisClient.NET.nuspec
+++ b/BuildNuGetPackage/WhoisClient.NET.nuspec
@@ -58,11 +58,11 @@
     <tags>whois</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.4">
-        <dependency id="IPAddressRange" version="2.0.0.3" />
+        <dependency id="IPAddressRange" version="3.2.0.0" />
         <dependency id="NETStandard.Library" version="1.4.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net45">
-        <dependency id="IPAddressRange" version="2.0.0.3" />
+        <dependency id="IPAddressRange" version="3.2.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/WhoisClient.NET/WhoisClient.NET.Test/WhoisClient.NET.Test.csproj
+++ b/WhoisClient.NET/WhoisClient.NET.Test/WhoisClient.NET.Test.csproj
@@ -39,8 +39,8 @@
     <Reference Include="ChainingAssertion, Version=1.8.1.3, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\ChainingAssertion.Bin.1.8.1.3\lib\net45\ChainingAssertion.dll</HintPath>
     </Reference>
-    <Reference Include="IPAddressRange, Version=2.0.0.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\IPAddressRange.2.0.0.3\lib\net45\IPAddressRange.dll</HintPath>
+    <Reference Include="IPAddressRange, Version=3.2.0.0, Culture=neutral, PublicKeyToken=578e3c3d17e7c751, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IPAddressRange.3.2.0\lib\net45\IPAddressRange.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/WhoisClient.NET/WhoisClient.NET.Test/packages.config
+++ b/WhoisClient.NET/WhoisClient.NET.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ChainingAssertion.Bin" version="1.8.1.3" targetFramework="net45" />
-  <package id="IPAddressRange" version="2.0.0.3" targetFramework="net45" />
+  <package id="IPAddressRange" version="3.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>

--- a/WhoisClient.NET/WhoisClient.NET.csproj
+++ b/WhoisClient.NET/WhoisClient.NET.csproj
@@ -39,8 +39,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="IPAddressRange, Version=2.0.0.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IPAddressRange.2.0.0.3\lib\net45\IPAddressRange.dll</HintPath>
+    <Reference Include="IPAddressRange, Version=3.2.0.0, Culture=neutral, PublicKeyToken=578e3c3d17e7c751, processorArchitecture=MSIL">
+      <HintPath>..\packages\IPAddressRange.3.2.0\lib\net45\IPAddressRange.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WhoisClient.NET/packages.config
+++ b/WhoisClient.NET/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IPAddressRange" version="2.0.0.3" targetFramework="net45" />
+  <package id="IPAddressRange" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/WhoisClient.NETCore/WhoisClient.NETCore.csproj
+++ b/WhoisClient.NETCore/WhoisClient.NETCore.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ipaddressrange" Version="2.0.0.3" />
+    <PackageReference Include="ipaddressrange" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Because IPAddressRange compatibility broke between v2 and v3, it's not possible use the current version of WhoisClient.NET in the same project as IPAddressRange v3.  This PR bumps the dependency to 3.2 (it doesn't matter which v3.x version is used, so I chosen the latest stable - feel free to pick a lower one if you prefer).

This might be considered a breaking change if someone is using WhoisClient.NET and IPAddressRange v2.