### PR TITLE
Wrong range Assumption

### DIFF
--- a/WhoisClient.NET.Test.Core20/IpTests.cs
+++ b/WhoisClient.NET.Test.Core20/IpTests.cs
@@ -10,7 +10,7 @@ namespace WhoisClient_NET.Test
         [InlineData(@"4.4.4.4", @"Level 3 Communications, Inc. LVLT-STATIC-4-4-16 (NET-4-4-0-0-1)", @"4.4.0.0-4.4.255.255")]
         [InlineData(@"65.100.170.169", @"Alana Scheffield USW-FFCF (NET-65-100-170-168-1)", @"65.100.170.168-65.100.170.175")]
         [InlineData(@"108.234.177.20", @"AT&T Corp.", @"108.192.0.0-108.255.255.255")]
-        [InlineData(@"190.190.132.64", @"Telecom Argentina S.A.", @"190.0.0.0-190.1.255.255")]
+        [InlineData(@"190.190.132.64", @"Telecom Argentina S.A.", @"190.190.0.0-190.191.255.255")]
         [InlineData(@"31.116.94.96", @"EE route", @"31.64.0.0-31.127.255.255")]
         public void WhoisClientTest(string ip, string expectedOrgName, string expectedAddressRange)
         {
@@ -23,7 +23,7 @@ namespace WhoisClient_NET.Test
         [InlineData(@"4.4.4.4", @"Level 3 Communications, Inc. LVLT-STATIC-4-4-16 (NET-4-4-0-0-1)", @"4.4.0.0-4.4.255.255")]
         [InlineData(@"65.100.170.169", @"Alana Scheffield USW-FFCF (NET-65-100-170-168-1)", @"65.100.170.168-65.100.170.175")]
         [InlineData(@"108.234.177.20", @"AT&T Corp.", @"108.192.0.0-108.255.255.255")]
-        [InlineData(@"190.190.132.64", @"Telecom Argentina S.A.", @"190.0.0.0-190.1.255.255")]
+        [InlineData(@"190.190.132.64", @"Telecom Argentina S.A.", @"190.190.0.0-190.191.255.255")]
         [InlineData(@"31.116.94.96", @"EE route", @"31.64.0.0-31.127.255.255")]
         public async Task WhoisClientAsyncTest(string ip, string expectedOrgName, string expectedAddressRange)
         {

--- a/WhoisClient.NET/WhoisResponse.cs
+++ b/WhoisClient.NET/WhoisResponse.cs
@@ -79,7 +79,17 @@ namespace Whois.NET
                 RegexOptions.Multiline);
             if (m2.Success)
             {
-                this.AddressRange = IPAddressRange.Parse(m2.Groups["adr"].Value);
+                var adr = m2.Groups["adr"].Value;
+                if (adr.Count(c => c == '.') < 3 && adr.Contains('/')) 
+                {
+                    var arrAdr = adr.Split('/');
+                    var ip = arrAdr[0];
+                    var suffix = arrAdr[1];
+                    for (var i = 3; i > adr.Count(c => c == '.'); i--)
+                        ip += ".0";
+                    adr = $"{ip}/{suffix}";
+                }
+                this.AddressRange = IPAddressRange.Parse(adr);
             }
 
             // resolve ARIN Address Range.


### PR DESCRIPTION
Test IP address from Telecom Argentina S.A. expected wrong data.
LACNIC answers in shortened CIDR form 190.190/15 which in fact is 190.190.0.0/15 and not the wronly assumed 190.0.0.190/15 (which does not include the input parameter IP).
Wrong assumption due to seemingly wrong implementation by the framework to analyze 190.190/15 correctly. The expected false results were only met because in fact the method by which the AddressRange is analyzed returns false data.