### PR TITLE
Add whois: <server> type referral regex

### DIFF
--- a/WhoisClient.NET/WhoisClient.cs
+++ b/WhoisClient.NET/WhoisClient.cs
@@ -21,6 +21,7 @@ namespace Whois.NET
                 @"(^ReferralServer:\W+whois://(?<refsvr>[^:\r\n]+)(:(?<port>\d+))?)|" +
                 @"(^\s*(Registrar\s+)?Whois Server:\s*(?<refsvr>[^:\r\n]+)(:(?<port>\d+))?)|" +
                 @"(^\s*refer:\s*(?<refsvr>[^:\r\n]+)(:(?<port>\d+))?)|" +
+                @"(^\s*whois:\s*(?<refsvr>[^:\r\n]+)(:(?<port>\d+))?)|" +
                 @"(^remarks:\W+.*(?<refsvr>whois\.[0-9a-z\-\.]+\.[a-z]{2,})(:(?<port>\d+))?)",
                 RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
 


### PR DESCRIPTION
For certain queries, ARIN whois server skips the `refer:` reponse and only returns a `whois:` response, i.e.:

```
% IANA WHOIS server
% for more information on IANA, visit http://www.iana.org
% This query returned 1 object

inet6num:     xxxx::/23
organisation: RIPE NCC
status:       ALLOCATED

whois:        whois.ripe.net

changed:      2004-06-11
source:       IANA
```

This changes ensures that gets picked up.