### PR TITLE
Handling of alternative JPNIC response format & Rethrow transport exceptions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+v.5.0.1
+- Added parsing of alternative JPNIC response format (without key letters)
+- Fixed tests
+- Added ability to rethrow transport exceptions that've occurred during WHOIS request instead of swallowing them
+
 v.5.0.0
 - Update the target frameworks
 - Improvement: aware "whois: <server>" syntax for referral servers

--- a/WhoisClient.NET.Test/IpTests.cs
+++ b/WhoisClient.NET.Test/IpTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Net.Sockets;
+using NUnit.Framework;
 using Whois.NET;
 
 namespace WhoisClient_NET.Test;
@@ -11,8 +12,8 @@ public class IpTests
         // string ip, string expectedOrgName, string expectedAddressRange
         new object[] { @"4.4.4.4", @"Level 3 Parent, LLC", @"4.0.0.0-4.127.255.255" },
         new object[] { @"65.100.170.169", @"CenturyLink Communications, LLC", @"65.100.0.0-65.103.255.255" },
-        new object[] { @"108.234.177.20", @"AT&T Corp.", @"108.192.0.0-108.255.255.255" },
-        new object[] { @"31.116.94.96", @"EE route", @"31.64.0.0-31.127.255.255" },
+        new object[] { @"108.234.177.20", @"AT&T Enterprises, LLC", @"108.192.0.0-108.255.255.255" },
+        new object[] { @"31.116.94.96", @"EE route", @"31.90.0.0-31.127.255.255" },
         new object[] { @"104.130.122.229", @"Rackspace Hosting", "104.130.0.0-104.130.255.255" },
         new object[] { @"2600::", @"Sprint", "2600::-2600:f:ffff:ffff:ffff:ffff:ffff:ffff" },
     };
@@ -33,5 +34,38 @@ public class IpTests
         var response = await WhoisClient.QueryAsync(ip);
         response.OrganizationName.Is(expectedOrgName);
         response.AddressRange.ToString().Is(expectedAddressRange);
+    }
+
+    [Test]
+    public void RawQuery_InvalidWhoisServerSpecified_TransportExceptionSwallowed()
+    {
+        var response = WhoisClient.RawQuery("4.4.4.4", server: "unknown.server.pp");
+
+        response.Is(string.Empty);
+    }
+
+    [Test]
+    public void RawQuery_InvalidWhoisServerSpecified_TransportExceptionRethrown()
+    {
+        TestDelegate action = () => WhoisClient.RawQuery("4.4.4.4", server: "unknown.server.pp", rethrowExceptions: true);
+
+        var exception = Assert.Throws<AggregateException>(action)!;
+        exception.InnerException.IsInstanceOf<SocketException>();
+    }
+
+    [Test]
+    public async Task RawQueryAsync_InvalidWhoisServerSpecified_TransportExceptionSwallowed()
+    {
+        var response = await WhoisClient.RawQueryAsync("4.4.4.4", server: "unknown.server.pp");
+
+        response.Is(string.Empty);
+    }
+
+    [Test]
+    public void RawQueryAsync_InvalidWhoisServerSpecified_TransportExceptionRethrown()
+    {
+        AsyncTestDelegate action = () => WhoisClient.RawQueryAsync("4.4.4.4", server: "unknown.server.pp", rethrowExceptions: true);
+
+        Assert.ThrowsAsync<SocketException>(action);
     }
 }

--- a/WhoisClient.NET.Test/IpTests.cs
+++ b/WhoisClient.NET.Test/IpTests.cs
@@ -54,6 +54,23 @@ public class IpTests
     }
 
     [Test]
+    public void Query_With3Retries_InvalidWhoisServerSpecified_TransportExceptionSwallowed()
+    {
+        var response = WhoisClient.Query("4.4.4.4", server: "unknown.server.pp", retries: 3);
+
+        response.Raw.Is(string.Empty);
+    }
+
+    [Test]
+    public void Query_With3Retries_InvalidWhoisServerSpecified_TransportExceptionRethrown()
+    {
+        TestDelegate action = () => WhoisClient.Query("4.4.4.4", server: "unknown.server.pp", retries: 3, rethrowExceptions: true);
+
+        var exception = Assert.Throws<AggregateException>(action)!;
+        exception.InnerException.IsInstanceOf<SocketException>();
+    }
+
+    [Test]
     public async Task RawQueryAsync_InvalidWhoisServerSpecified_TransportExceptionSwallowed()
     {
         var response = await WhoisClient.RawQueryAsync("4.4.4.4", server: "unknown.server.pp");
@@ -65,6 +82,23 @@ public class IpTests
     public void RawQueryAsync_InvalidWhoisServerSpecified_TransportExceptionRethrown()
     {
         AsyncTestDelegate action = () => WhoisClient.RawQueryAsync("4.4.4.4", server: "unknown.server.pp", rethrowExceptions: true);
+
+        Assert.ThrowsAsync<SocketException>(action);
+    }
+
+    [Test]
+    public async Task QueryAsync_With3Retries_InvalidWhoisServerSpecified_TransportExceptionSwallowed()
+    {
+        var response = await WhoisClient.QueryAsync("4.4.4.4", server: "unknown.server.pp", retries: 3);
+
+        response.Raw.Is(string.Empty);
+    }
+
+    [Test]
+    public void QueryAsync_With3Retries_InvalidWhoisServerSpecified_TransportExceptionRethrown()
+    {
+        AsyncTestDelegate action = () => WhoisClient.QueryAsync(
+            "4.4.4.4", server: "unknown.server.pp", retries: 3, rethrowExceptions: true);
 
         Assert.ThrowsAsync<SocketException>(action);
     }

--- a/WhoisClient.NET.Test/WhoisResponseTest.cs
+++ b/WhoisClient.NET.Test/WhoisResponseTest.cs
@@ -17,6 +17,18 @@ public class WhoisResponseTest
         "m. [管理者連絡窓口]             HH11825JP\r\n" +
         "n. [技術連絡担当者]             MO5920JP\r\n";
 
+    private readonly string ResponseJPWithoutKeyLetters =
+        "Network Information: [ネットワーク情報]\r\n" +
+        "[IPネットワークアドレス]        27.80.0.0/12\r\n" +
+        "[ネットワーク名]\r\n" +
+        "[組織名]                        KDDI株式会社\r\n" +
+        "[Organization]                  KDDI CORPORATION\r\n" +
+        "[管理者連絡窓口]                JP00000127\r\n" +
+        "[技術連絡担当者]                JP00000181\r\n" +
+        "[Abuse]                         abuse@dion.ne.jp\r\n" +
+        "[割振年月日]                    2010/04/28\r\n" +
+        "[最終更新]                      2010/04/28 10:50:55(JST)\r\n";
+
     [Test]
     public void OrganizationNameTest_JP()
     {
@@ -25,11 +37,28 @@ public class WhoisResponseTest
     }
 
     [Test]
+    public void OrganizationNameTest_JP_WithoutKeyLetters()
+    {
+        new WhoisResponse(null, this.ResponseJPWithoutKeyLetters)
+            .OrganizationName.Is("KDDI株式会社");
+    }
+
+    [Test]
     public void AddressRangeTest_JP()
     {
         var r = new WhoisResponse(null, this.ResponseJP);
+        r.AddressRange.IsNotNull();
         r.AddressRange.Begin.ToString().Is("192.41.192.0");
         r.AddressRange.End.ToString().Is("192.41.192.255");
+    }
+
+    [Test]
+    public void AddressRangeTest_JP_WithoutKeyLetters()
+    {
+        var r = new WhoisResponse(null, this.ResponseJPWithoutKeyLetters);
+        r.AddressRange.IsNotNull();
+        r.AddressRange.Begin.ToString().Is("27.80.0.0");
+        r.AddressRange.End.ToString().Is("27.95.255.255");
     }
 
     private readonly string ResponseEN1 =

--- a/WhoisClient.NET/WhoisClient.NET.csproj
+++ b/WhoisClient.NET/WhoisClient.NET.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>WhoisClient</AssemblyName>
     <Product>WhoisClient.NET</Product>
     <Authors>J.Sakamoto, Keith J. Jones, Martijn Storck</Authors>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <Copyright>Copyright 2012-2023 J.Sakamoto; Copyright Keith J. Jones, 2016; Martijn Storck, 2023, Ms-PL License.</Copyright>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jsakamoto/WhoisClient.NET/</PackageProjectUrl>

--- a/WhoisClient.NET/WhoisClient.cs
+++ b/WhoisClient.NET/WhoisClient.cs
@@ -97,8 +97,16 @@ namespace Whois.NET
             // Continue to connect within the retries number
             while (string.IsNullOrWhiteSpace(rawResponse) && iteration < retries)
             {
-                rawResponse = RawQuery(GetQueryStatement(server, query), server, port, encoding, timeout, rethrowExceptions);
-                iteration++;
+                try
+                {
+                    iteration++;
+                    rawResponse = RawQuery(
+                        GetQueryStatement(server, query), server, port, encoding, timeout, rethrowExceptions);
+                }
+                catch (Exception) when (iteration < retries)
+                {
+                    rawResponse = null;
+                }
             }
 
             if (HasReferral(rawResponse, server, out var refsvr, out var refport))
@@ -133,9 +141,16 @@ namespace Whois.NET
             // Continue to connect within the retries number
             while (string.IsNullOrWhiteSpace(rawResponse) && iteration < retries)
             {
-                rawResponse = await RawQueryAsync(
-                    GetQueryStatement(server, query), server, port, encoding, timeout, rethrowExceptions, token).ConfigureAwait(false);
-                iteration++;
+                try
+                {
+                    iteration++;
+                    rawResponse = await RawQueryAsync(
+                        GetQueryStatement(server, query), server, port, encoding, timeout, rethrowExceptions, token).ConfigureAwait(false);
+                }
+                catch (Exception) when (iteration < retries)
+                {
+                    rawResponse = null;
+                }
             }
 
             if (HasReferral(rawResponse, server, out var refsvr, out var refport))
@@ -228,7 +243,7 @@ namespace Whois.NET
                     return string.Empty;
                 }
             }
-            catch (AggregateException aex) when (aex.InnerException is SocketException)
+            catch
             {
                 Thread.Sleep(200);
 

--- a/WhoisClient.NET/WhoisClient.cs
+++ b/WhoisClient.NET/WhoisClient.cs
@@ -34,9 +34,10 @@ namespace Whois.NET
         /// <param name="encoding">Encoding method to decode the result of query. This parameter is optional (default value is null) to using ASCII encoding.</param>
         /// <param name="timeout">A timespan to limit the connection attempt, in seconds.</param>
         /// <param name="retries">The number of times a connection will be attempted.</param>
+        /// <param name="rethrowExceptions">Rethrow any caught exceptions instead of swallowing them</param>
         /// <returns>The strong typed result of query which responded from WHOIS server.</returns>
         public static WhoisResponse Query(string query, string server = null, int port = 43,
-            Encoding encoding = null, int timeout = 600, int retries = 10)
+            Encoding encoding = null, int timeout = 600, int retries = 10, bool rethrowExceptions = false)
         {
             encoding = encoding ?? Encoding.ASCII;
 
@@ -45,7 +46,7 @@ namespace Whois.NET
                 server = "whois.iana.org";
             }
 
-            return QueryRecursive(query, new List<string> { server }, port, encoding, timeout, retries);
+            return QueryRecursive(query, new List<string> { server }, port, encoding, timeout, retries, rethrowExceptions);
         }
 
         /// <summary>
@@ -57,10 +58,11 @@ namespace Whois.NET
         /// <param name="encoding">Encoding method to decode the result of query. This parameter is optional (default value is null) to using ASCII encoding.</param>
         /// <param name="timeout">A timespan to limit the connection attempt, in seconds.</param>
         /// <param name="retries">The number of times a connection will be attempted.</param>
+        /// <param name="rethrowExceptions">Rethrow any caught exceptions instead of swallowing them</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>The strong typed result of query which responded from WHOIS server.</returns>
         public static async Task<WhoisResponse> QueryAsync(string query, string server = null, int port = 43,
-            Encoding encoding = null, int timeout = 600, int retries = 10, CancellationToken token = default(CancellationToken))
+            Encoding encoding = null, int timeout = 600, int retries = 10, bool rethrowExceptions = false, CancellationToken token = default(CancellationToken))
         {
             encoding = encoding ?? Encoding.ASCII;
 
@@ -69,7 +71,8 @@ namespace Whois.NET
                 server = "whois.iana.org";
             }
 
-            return await QueryRecursiveAsync(query, new List<string> { server }, port, encoding, timeout, retries, token).ConfigureAwait(false);
+            return await QueryRecursiveAsync(
+                query, new List<string> { server }, port, encoding, timeout, retries, rethrowExceptions, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,9 +84,10 @@ namespace Whois.NET
         /// <param name="encoding">The encoding to use during the query.</param>
         /// <param name="timeout">A timespan to limit the connection attempt, in seconds.</param>
         /// <param name="retries">The number of times a connection will be attempted.</param>
+        /// <param name="rethrowExceptions">Rethrow any caught exceptions instead of swallowing them</param>
         /// <returns>A whois response structure containing the results of the whois queries.</returns>
         private static WhoisResponse QueryRecursive(string query, List<string> servers, int port,
-            Encoding encoding, int timeout = 600, int retries = 10)
+            Encoding encoding, int timeout = 600, int retries = 10, bool rethrowExceptions = false)
         {
             var server = servers.Last();
 
@@ -93,14 +97,14 @@ namespace Whois.NET
             // Continue to connect within the retries number
             while (string.IsNullOrWhiteSpace(rawResponse) && iteration < retries)
             {
-                rawResponse = RawQuery(GetQueryStatement(server, query), server, port, encoding, timeout);
+                rawResponse = RawQuery(GetQueryStatement(server, query), server, port, encoding, timeout, rethrowExceptions);
                 iteration++;
             }
 
             if (HasReferral(rawResponse, server, out var refsvr, out var refport))
             {
                 servers.Add(refsvr);
-                return QueryRecursive(query, servers, refport, encoding, timeout, retries);
+                return QueryRecursive(query, servers, refport, encoding, timeout, retries, rethrowExceptions);
             }
             else
                 return new WhoisResponse(servers.ToArray(), rawResponse);
@@ -115,10 +119,11 @@ namespace Whois.NET
         /// <param name="encoding">The encoding to use during the query.</param>
         /// <param name="timeout">A timespan to limit the connection attempt, in seconds.</param>
         /// <param name="retries">The number of times a connection will be attempted.</param>
+        /// <param name="rethrowExceptions">Rethrow any caught exceptions instead of swallowing them</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>A whois response structure containing the results of the whois queries.</returns>
         private static async Task<WhoisResponse> QueryRecursiveAsync(string query, List<string> servers, int port,
-            Encoding encoding, int timeout = 600, int retries = 10, CancellationToken token = default(CancellationToken))
+            Encoding encoding, int timeout = 600, int retries = 10, bool rethrowExceptions = false, CancellationToken token = default(CancellationToken))
         {
             var server = servers.Last();
 
@@ -128,14 +133,16 @@ namespace Whois.NET
             // Continue to connect within the retries number
             while (string.IsNullOrWhiteSpace(rawResponse) && iteration < retries)
             {
-                rawResponse = await RawQueryAsync(GetQueryStatement(server, query), server, port, encoding, timeout, token).ConfigureAwait(false);
+                rawResponse = await RawQueryAsync(
+                    GetQueryStatement(server, query), server, port, encoding, timeout, rethrowExceptions, token).ConfigureAwait(false);
                 iteration++;
             }
 
             if (HasReferral(rawResponse, server, out var refsvr, out var refport))
             {
                 servers.Add(refsvr);
-                return await QueryRecursiveAsync(query, servers, refport, encoding, timeout, retries, token).ConfigureAwait(false);
+                return await QueryRecursiveAsync(
+                    query, servers, refport, encoding, timeout, retries, rethrowExceptions, token).ConfigureAwait(false);
             }
             else
                 return new WhoisResponse(servers.ToArray(), rawResponse);
@@ -198,23 +205,36 @@ namespace Whois.NET
         /// <param name="port">TCP port number to connect whois server. This parameter is optional, and default value is 43.</param>
         /// <param name="encoding">Encoding method to decode the result of query. This parameter is optional (default value is null) to using ASCII encoding.</param>
         /// <param name="timeout">A timespan to limit the connection attempt, in seconds.  Function returns empty string if it times out.</param>
+        /// <param name="rethrowExceptions">Rethrow any caught exceptions instead of swallowing them</param>
         /// <returns>The raw data decoded by encoding parameter from the WHOIS server that responded, or an empty string if a connection cannot be established.</returns>
         public static string RawQuery(string query, string server, int port = 43,
-            Encoding encoding = null, int timeout = 600)
+            Encoding encoding = null, int timeout = 600, bool rethrowExceptions = false)
         {
             encoding = encoding ?? Encoding.ASCII;
             var tcpClient = new TcpClient();
 
-            // Async connect
-            var t = tcpClient.ConnectAsync(server, port);
-            t.ConfigureAwait(false);
+            try
+            {
+                // Async connect
+                var t = tcpClient.ConnectAsync(server, port);
+                t.ConfigureAwait(false);
 
-            // Wait at most timeout
-            var success = t.Wait(TimeSpan.FromSeconds(timeout));
+                // Wait at most timeout
+                var success = t.Wait(TimeSpan.FromSeconds(timeout));
 
-            if (!success)
+                if (!success)
+                {
+                    Thread.Sleep(200);
+                    return string.Empty;
+                }
+            }
+            catch (AggregateException aex) when (aex.InnerException is SocketException)
             {
                 Thread.Sleep(200);
+
+                if (rethrowExceptions)
+                    throw;
+
                 return string.Empty;
             }
 
@@ -248,6 +268,10 @@ namespace Whois.NET
             {
                 tcpClient.Close();
                 Thread.Sleep(200);
+
+                if (rethrowExceptions)
+                    throw;
+
                 return res.ToString();
             }
             finally
@@ -265,11 +289,14 @@ namespace Whois.NET
         /// <param name="port">TCP port number to connect whois server. This parameter is optional, and default value is 43.</param>
         /// <param name="encoding">Encoding method to decode the result of query. This parameter is optional (default value is null) to using ASCII encoding.</param>
         /// <param name="timeout">A timespan to limit the connection attempt, in seconds.  Function returns empty string if it times out.</param>
+        /// <param name="rethrowExceptions">Rethrow any caught exceptions instead of swallowing them</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>The raw data decoded by encoding parameter from the WHOIS server that responded, or an empty string if a connection cannot be established.</returns>
         public static async Task<string> RawQueryAsync(string query, string server, int port = 43,
-            Encoding encoding = null, int timeout = 600, CancellationToken token = default(CancellationToken))
+            Encoding encoding = null, int timeout = 600, bool rethrowExceptions = false, CancellationToken token = default(CancellationToken))
         {
+            encoding = encoding ?? Encoding.ASCII;
+
             var tcpClient = new TcpClient();
 
             // Async connect
@@ -280,6 +307,10 @@ namespace Whois.NET
             catch (SocketException)
             {
                 await Task.Delay(200).ConfigureAwait(false);
+
+                if (rethrowExceptions)
+                    throw;
+
                 return string.Empty;
             }
 
@@ -293,17 +324,17 @@ namespace Whois.NET
                     s.ReadTimeout = timeout * 1000;
 
                     var queryBytes = Encoding.ASCII.GetBytes(query + "\r\n");
-                    await s.WriteAsync(queryBytes, 0, queryBytes.Length).ConfigureAwait(false);
-                    await s.FlushAsync().ConfigureAwait(false);
+                    await s.WriteAsync(queryBytes, 0, queryBytes.Length, token).ConfigureAwait(false);
+                    await s.FlushAsync(token).ConfigureAwait(false);
 
                     const int buffSize = 8192;
                     var readBuff = new byte[buffSize];
                     var cbRead = default(int);
                     do
                     {
-                        cbRead = await s.ReadAsync(readBuff, 0, Math.Min(buffSize, tcpClient.Available)).ConfigureAwait(false);
+                        cbRead = await s.ReadAsync(readBuff, 0, Math.Min(buffSize, tcpClient.Available), token).ConfigureAwait(false);
                         res.Append(encoding.GetString(readBuff, 0, cbRead));
-                        if (cbRead > 0 || res.Length == 0) await Task.Delay(100).ConfigureAwait(false);
+                        if (cbRead > 0 || res.Length == 0) await Task.Delay(100, token).ConfigureAwait(false);
                     } while (cbRead > 0 || res.Length == 0);
 
                     return res.ToString();
@@ -313,6 +344,10 @@ namespace Whois.NET
             {
                 tcpClient.Close();
                 await Task.Delay(200).ConfigureAwait(false);
+
+                if (rethrowExceptions)
+                    throw;
+
                 return res.ToString();
             }
             finally

--- a/WhoisClient.NET/WhoisResponse.cs
+++ b/WhoisClient.NET/WhoisResponse.cs
@@ -60,7 +60,7 @@ namespace Whois.NET
 
             // resolve Organization Name.
             var m1 = Regex.Match(this.Raw,
-                @"(^f\.\W*\[組織名\]\W+(?<orgName>[^\r\n]+))|" +
+                @"(^(f\.)?\W*\[組織名\]\W+(?<orgName>[^\r\n]+))|" +
                 @"(^\s*(OrgName|descr|Registrant Organization|owner):\W+(?<orgName>[^\r\n]+))",
                 RegexOptions.Multiline);
             if (m1.Success)
@@ -70,7 +70,7 @@ namespace Whois.NET
 
             // resolve Address Range.
             var m2 = Regex.Match(this.Raw,
-                @"(^a.\W*\[IPネットワークアドレス\]\W+(?<adr>[^\r\n]+))|" +
+                @"(^(a\.)?\W*\[IPネットワークアドレス\]\W+(?<adr>[^\r\n]+))|" +
                 @"(^(NetRange|CIDR|inetnum):\W+(?<adr>[^\r\n]+))",
                 RegexOptions.Multiline);
             if (m2.Success)


### PR DESCRIPTION
- Added handling of alternative JPNIC response format
```
Network Information: [ネットワーク情報]
[IPネットワークアドレス]        27.80.0.0/12
[ネットワーク名]                
[組織名]                        KDDI株式会社
[Organization]                  KDDI CORPORATION
[管理者連絡窓口]                JP00000127
[技術連絡担当者]                JP00000181
[Abuse]                         abuse@dion.ne.jp
[割振年月日]                    2010/04/28
[最終更新]                      2010/04/28 10:50:55(JST)
```
- Added ability to rethrow transport-level exceptions instead of swallowing them. Providing ability to view and log the whole stacktrace may help while debugging.