### PR TITLE
Moved TcpClient creation to separate class (in case there's something special to do before WHOIS request)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+v.5.3.0
+- Fixed potential infinite loop in socket reading method
+
 v.5.2.0
 - Moved TcpClient creation to separate class, enabling usage in special cases like flowing traffic through SOCKS proxy
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+v.5.2.0
+- Moved TcpClient creation to separate class, enabling usage in special cases like flowing traffic through SOCKS proxy
+
 v.5.1.0
 - Added parsing of alternative JPNIC response format (without key letters)
 - Fixed tests

--- a/WhoisClient.NET/DefaultTcpConnector.cs
+++ b/WhoisClient.NET/DefaultTcpConnector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Whois.NET
@@ -11,7 +12,10 @@ namespace Whois.NET
         private DefaultTcpConnector()
         { }
 
-        public async Task<TcpClient> ConnectAsync(string server, int port)
+        public async Task<TcpClient> ConnectAsync(
+            string server, 
+            int port,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(server))
             {

--- a/WhoisClient.NET/DefaultTcpConnector.cs
+++ b/WhoisClient.NET/DefaultTcpConnector.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Whois.NET
+{
+    internal sealed class DefaultTcpConnector : ITcpConnector
+    {
+        public static DefaultTcpConnector Instance { get; } = new DefaultTcpConnector();
+
+        private DefaultTcpConnector()
+        { }
+
+        public async Task<TcpClient> ConnectAsync(string server, int port)
+        {
+            if (string.IsNullOrWhiteSpace(server))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(server));
+            }
+
+            if (port <= 0 || port > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(port));
+            }
+
+            var tcpClient = new TcpClient();
+
+            await tcpClient.ConnectAsync(server, port);
+
+            return tcpClient;
+        }
+    }
+}

--- a/WhoisClient.NET/IQueryOptions.cs
+++ b/WhoisClient.NET/IQueryOptions.cs
@@ -23,5 +23,10 @@ namespace Whois.NET
         /// Gets whether rethrow any caught exceptions instead of swallowing them. The default value is false.
         /// </summary>
         bool RethrowExceptions { get; }
+
+        /// <summary>
+        /// Gets or sets connection manager instance. Replace it if you need to create a connection in specific way, for example, over SOCKS proxy.
+        /// </summary>
+        ITcpConnector TcpConnector { get; }
     }
 }

--- a/WhoisClient.NET/ITcpConnector.cs
+++ b/WhoisClient.NET/ITcpConnector.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Whois.NET
@@ -13,7 +14,8 @@ namespace Whois.NET
         /// </summary>
         /// <param name="server">Server hostname or address</param>
         /// <param name="port">TCP port</param>
+        /// <param name="cancellationToken"></param>
         /// <returns><see cref="TcpClient"/> connected to the specified endpoint</returns>
-        Task<TcpClient> ConnectAsync(string server, int port);
+        Task<TcpClient> ConnectAsync(string server, int port, CancellationToken cancellationToken = default);
     }
 }

--- a/WhoisClient.NET/ITcpConnector.cs
+++ b/WhoisClient.NET/ITcpConnector.cs
@@ -1,0 +1,19 @@
+﻿using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Whois.NET
+{
+    /// <summary>
+    /// TCP connection manager
+    /// </summary>
+    public interface ITcpConnector
+    {
+        /// <summary>
+        /// Connect to specified endpoint and return the resulting <see cref="TcpClient"/>
+        /// </summary>
+        /// <param name="server">Server hostname or address</param>
+        /// <param name="port">TCP port</param>
+        /// <returns><see cref="TcpClient"/> connected to the specified endpoint</returns>
+        Task<TcpClient> ConnectAsync(string server, int port);
+    }
+}

--- a/WhoisClient.NET/WhoisClient.NET.csproj
+++ b/WhoisClient.NET/WhoisClient.NET.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>WhoisClient</AssemblyName>
     <Product>WhoisClient.NET</Product>
     <Authors>J.Sakamoto, Keith J. Jones, Martijn Storck, Makaopior</Authors>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <Copyright>Copyright 2012-2025 J.Sakamoto; 2016 Keith J. Jones; 2023 Martijn Storck; 2025 Makaopior; Ms-PL License.</Copyright>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jsakamoto/WhoisClient.NET/</PackageProjectUrl>

--- a/WhoisClient.NET/WhoisClient.NET.csproj
+++ b/WhoisClient.NET/WhoisClient.NET.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>WhoisClient</AssemblyName>
     <Product>WhoisClient.NET</Product>
     <Authors>J.Sakamoto, Keith J. Jones, Martijn Storck, Makaopior</Authors>
-    <Version>5.2.0</Version>
+    <Version>5.3.0</Version>
     <Copyright>Copyright 2012-2025 J.Sakamoto; 2016 Keith J. Jones; 2023 Martijn Storck; 2025 Makaopior; Ms-PL License.</Copyright>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jsakamoto/WhoisClient.NET/</PackageProjectUrl>

--- a/WhoisClient.NET/WhoisClient.cs
+++ b/WhoisClient.NET/WhoisClient.cs
@@ -392,7 +392,7 @@ namespace Whois.NET
             // Async connect
             try
             {
-                tcpClient = await options.TcpConnector.ConnectAsync(server.Host, server.Port)
+                tcpClient = await options.TcpConnector.ConnectAsync(server.Host, server.Port, token)
                     .ConfigureAwait(false);
             }
             catch (SocketException)

--- a/WhoisClient.NET/WhoisClient.cs
+++ b/WhoisClient.NET/WhoisClient.cs
@@ -318,8 +318,9 @@ namespace Whois.NET
                     {
                         cbRead = s.Read(readBuff, 0, readBuff.Length);
                         res.Append(options.Encoding.GetString(readBuff, 0, cbRead));
-                        if (cbRead > 0 || res.Length == 0) Thread.Sleep(100);
-                    } while (cbRead > 0 || res.Length == 0);
+                        if (cbRead > 0) 
+                            Thread.Sleep(100);
+                    } while (cbRead > 0);
 
                     return res.ToString();
                 }
@@ -423,10 +424,11 @@ namespace Whois.NET
                     var cbRead = default(int);
                     do
                     {
-                        cbRead = await s.ReadAsync(readBuff, 0, Math.Min(buffSize, tcpClient.Available), token).ConfigureAwait(false);
+                        cbRead = await s.ReadAsync(readBuff, 0, buffSize, token).ConfigureAwait(false);
                         res.Append(options.Encoding.GetString(readBuff, 0, cbRead));
-                        if (cbRead > 0 || res.Length == 0) await Task.Delay(100, token).ConfigureAwait(false);
-                    } while (cbRead > 0 || res.Length == 0);
+                        if (cbRead > 0) 
+                            await Task.Delay(100, token).ConfigureAwait(false);
+                    } while (cbRead > 0);
 
                     return res.ToString();
                 }

--- a/WhoisClient.NET/WhoisQueryOptions.cs
+++ b/WhoisClient.NET/WhoisQueryOptions.cs
@@ -36,5 +36,10 @@ namespace Whois.NET
         /// Gets or sets whether rethrow any caught exceptions instead of swallowing them. The default value is false.
         /// </summary>
         public bool RethrowExceptions { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets connection manager instance. Replace it if you need to create a connection in specific way, for example, over SOCKS proxy.
+        /// </summary>
+        public ITcpConnector TcpConnector { get; set; } = DefaultTcpConnector.Instance;
     }
 }


### PR DESCRIPTION
Hi,

I don't know if this functionality is useful, but in some cases it may benefit.
If TCP connection to WHOIS server should be created in special way (for example, through SOCKS proxy for environments without free internet access), users can leverage SOCKS client libraries to accomplish that.