### PR TITLE
Throw TimeoutException instead of OperationCanceledException when RawQueryAsync method times out

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+v.6.1.0
+- Throw TimeoutException instead of OperationCanceledException when RawQueryAsync method times out
+
 v.6.0.0
 - [BREAKING CHANGE] The Default timeout for communication with servers was changed to 2 seconds, and the default retry count was changed to 3 times (Issue #10 by Makaopior)
 - Improved resolving an organization name from a raw response text from a WHOIS server

--- a/WhoisClient.NET/WhoisClient.NET.csproj
+++ b/WhoisClient.NET/WhoisClient.NET.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>WhoisClient</AssemblyName>
     <Product>WhoisClient.NET</Product>
     <Authors>J.Sakamoto, Keith J. Jones, Martijn Storck, Makaopior</Authors>
-    <Version>6.0.0</Version>
+    <Version>6.1.0</Version>
     <Copyright>Copyright 2012-2025 J.Sakamoto; 2016 Keith J. Jones; 2023 Martijn Storck; 2025 Makaopior; Ms-PL License.</Copyright>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jsakamoto/WhoisClient.NET/</PackageProjectUrl>


### PR DESCRIPTION
`OperationCanceledException` is usually treated like "The underlying operation has been canceled, terminate the upstream too", and that's not what is to be expected from an ordinary timeout. `HttpClient` has a similar problem too.
Changed behavior so that cancelling the async socket IO operation throws `TimeoutException` instead of passing cancellation exception through.
